### PR TITLE
Adding coinrpc to pybitcoin

### DIFF
--- a/rpc/LICENSE
+++ b/rpc/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Halfmoon Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/rpc/MANIFEST.in
+++ b/rpc/MANIFEST.in
@@ -1,0 +1,1 @@
+include coinrpc/scripts/*

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1,0 +1,34 @@
+coinrpc
+=======
+
+Coinrpc is a python library for RPC calls to namecoind and bitcoind. Under the hood it uses [AuthProxy](https://github.com/jgarzik/python-bitcoinrpc). Coinrpc makes the following changes/additions to directly using the underlying RPC: 
+
+For Namecoind:
+
+  1. Support for managing a cluster of namecoind servers
+  2. Adds get_full_profile() that can fetch an Openname profile from a linked-list of key:value entries
+  3. Fixes the bug where value > 520 bytes can cause a key to become unusable
+  4. Logically separates name_transfer from name_update 
+  5. Adds reasonable default values for certain calls e.g., 100 as timeout for unlocking wallet
+  6. Adds calls for checking if a user is registered (True/False) and if a wallet is unlocked (True/False)
+  7. Better error handling 
+  
+## Installation:
+
+```
+pip install git+ssh://git@github.com/onenameio/coinrpc.git
+```
+
+By default bitcoind is turned off and the configuration of a public namecoind server is used. Custom namecoind/bitcoind servers can be used by setting the appropriate ENV VARIABLES (see [config.py](coinrpc/config.py)) e.g., by sourcing the following scripts:
+
+```
+source <path-to-dir>/coinrpc/scripts/setup_namecoind.sh 
+source <path-to-dir>/coinrpc/scripts/setup_bitcoind.sh
+```
+
+## Usage: 
+
+```
+from coinrpc import namecoind
+print namecoind.blocks()
+```

--- a/rpc/coinrpc/__init__.py
+++ b/rpc/coinrpc/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""
+    coinrpc
+    ~~~~~
+
+    :copyright: (c) 2014 by Halfmoon Labs
+    :license: MIT, see LICENSE for more details.
+"""
+
+from .config import NAMECOIND_ENABLED, BITCOIND_ENABLED
+
+if NAMECOIND_ENABLED:
+
+    from .namecoind_client import NamecoindClient
+    namecoind = NamecoindClient()  # start with default server settings
+
+
+if BITCOIND_ENABLED:
+
+    from .bitcoind_client import BitcoindClient
+    bitcoind = BitcoindClient()  # start with default server settings

--- a/rpc/coinrpc/bitcoind_client.py
+++ b/rpc/coinrpc/bitcoind_client.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+"""
+    coinrpc
+    ~~~~~
+
+    :copyright: (c) 2014 by Halfmoon Labs
+    :license: MIT, see LICENSE for more details.
+"""
+
+from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+from commontools import log, error_reply
+from coinkit import SATOSHIS_PER_COIN
+from coinkit import script_hex_to_address
+
+from .config import BITCOIND_SERVER, BITCOIND_PORT, BITCOIND_USER
+from .config import BITCOIND_PASSWD, BITCOIND_WALLET_PASSPHRASE
+from .config import BITCOIND_USE_HTTPS
+
+
+# ---------------------------------------
+class BitcoindClient(object):
+
+    def __init__(self, server=BITCOIND_SERVER, port=BITCOIND_PORT,
+                 user=BITCOIND_USER, passwd=BITCOIND_PASSWD,
+                 use_https=BITCOIND_USE_HTTPS,
+                 passphrase=BITCOIND_WALLET_PASSPHRASE, version_byte=0):
+
+        self.passphrase = passphrase
+        self.server = server
+
+        self.type = 'bitcoind'
+        self.version_byte = version_byte
+
+        if use_https:
+            http_string = 'https://'
+        else:
+            http_string = 'http://'
+
+        self.obj = AuthServiceProxy(http_string + user + ':' + passwd +
+                                    '@' + server + ':' + str(port))
+
+    def __getattr__(self, name):
+        """ changes the behavior of underlying authproxy to return the error
+            from bitcoind instead of raising JSONRPCException
+        """
+        func = getattr(self.__dict__['obj'], name)
+        if callable(func):
+            def my_wrapper(*args, **kwargs):
+                try:
+                    ret = func(*args, **kwargs)
+                except JSONRPCException as e:
+                    return e.error
+                else:
+                    return ret
+            return my_wrapper
+        else:
+            return func
+
+    # -----------------------------------
+    def blocks(self):
+
+        reply = self.obj.getinfo()
+
+        if 'blocks' in reply:
+            return reply['blocks']
+
+        return None
+
+    # -----------------------------------
+    def unlock_wallet(self, timeout=120):
+
+        try:
+            info = self.obj.walletpassphrase(self.passphrase, timeout)
+
+            if info is None:
+                return True
+        except:
+            pass
+
+        return False
+
+    # -----------------------------------
+    def sendtoaddress(self, bitcoinaddress, amount):
+
+        self.unlock_wallet()
+
+        try:
+            # ISSUE: should not be float, needs fix
+            status = self.obj.sendtoaddress(bitcoinaddress, float(amount))
+            return status
+        except Exception as e:
+            return error_reply(str(e))
+
+    # -----------------------------------
+    def validateaddress(self, bitcoinaddress):
+
+        try:
+            status = self.obj.validateaddress(bitcoinaddress)
+            return status
+        except Exception as e:
+            return error_reply(str(e))
+
+    # -----------------------------------
+    def importprivkey(self, bitcoinprivkey, label='import', rescan=False):
+
+        self.unlock_wallet()
+
+        try:
+            status = self.obj.importprivkey(bitcoinprivkey, label, rescan)
+            return status
+        except Exception as e:
+            return error_reply(str(e))
+
+    # -----------------------------------
+    def sendtousername(self, username, bitcoin_amount):
+
+        # Step 1: get the bitcoin address
+        from coinrpc import namecoind
+        data = namecoind.get_full_profile('u/' + username)
+
+        try:
+            bitcoin_address = data['bitcoin']['address']
+        except:
+            bitcoin_address = ""
+
+        reply = {}
+
+        # Step 2: send bitcoins to that address
+        if bitcoin_address != "":
+
+            if self.unlock_wallet():
+
+                # send the bitcoins
+                # ISSUE: should not be float, needs fix
+                info = self.sendtoaddress(bitcoin_address,
+                                          float(bitcoin_amount))
+
+                if 'status' in info and info['status'] == -1:
+                    return error_reply("couldn't send transaction")
+
+                reply['status'] = 200
+                reply['tx'] = info
+                return reply
+
+        return error_reply("couldn't send BTC")
+
+    # -----------------------------------
+    def format_unspents(self, unspents):
+        return [{
+            "transaction_hash": s["txid"],
+            "output_index": s["vout"],
+            "value": int(round(s["amount"]*SATOSHIS_PER_COIN)),
+            "script_hex": s["scriptPubKey"],
+            "confirmations": s["confirmations"]
+            }
+            for s in unspents
+        ]
+
+    # -----------------------------------
+    def get_unspents(self, address):
+        """ Get the spendable transaction outputs, also known as UTXOs or
+            unspent transaction outputs.
+
+            NOTE: this will only return unspents if the address provided is
+            present in the bitcoind server. Use the blockchain or chain API
+            to grab the unspents for arbitrary addresses.
+        """
+
+        all_unspents = self.obj.listunspent()
+
+        unspents = []
+        for u in all_unspents:
+            if 'address' not in u:
+                u['address'] = script_hex_to_address(u['scriptPubKey'],
+                                                     version_byte=self.version_byte)
+            if 'spendable' in u and u['spendable'] is False:
+                continue
+            if u['address'] == address:
+                unspents.append(u)
+
+        return self.format_unspents(unspents)
+
+    # -----------------------------------
+    def broadcast_transaction(self, hex_tx):
+        """ Dispatch a raw transaction to the network.
+        """
+
+        resp = self.obj.sendrawtransaction(hex_tx)
+        if len(resp) > 0:
+            return {'transaction_hash': resp, 'success': True}
+        else:
+            return error_reply('Invalid response from bitcoind.')

--- a/rpc/coinrpc/config.py
+++ b/rpc/coinrpc/config.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+    coinrpc
+    ~~~~~
+
+    :copyright: (c) 2014 by Halfmoon Labs
+    :license: MIT, see LICENSE for more details.
+"""
+
+import os
+
+NAMECOIND_ENABLED = True
+BITCOIND_ENABLED = True
+
+DEBUG = True
+
+VALUE_MAX_LIMIT = 520
+
+# --------------------------------------------------
+if NAMECOIND_ENABLED:
+
+    NAMECOIND_USE_HTTPS = True
+
+    try:
+        NAMECOIND_PORT = os.environ['NAMECOIND_PORT']
+        NAMECOIND_SERVER = os.environ['NAMECOIND_SERVER']
+        NAMECOIND_USER = os.environ['NAMECOIND_USER']
+        NAMECOIND_PASSWD = os.environ['NAMECOIND_PASSWD']
+    except:
+        # default settings with a public server
+        NAMECOIND_PORT = 8332
+        NAMECOIND_SERVER = 'nmcd.onename.com'
+        NAMECOIND_USER = 'opennamesystem'
+        NAMECOIND_PASSWD = 'opennamesystem'
+
+    try:
+        NAMECOIND_WALLET_PASSPHRASE = os.environ['NAMECOIND_WALLET_PASSPHRASE']
+    except:
+        NAMECOIND_WALLET_PASSPHRASE = ''
+
+    try:
+        from .config_local import MAIN_SERVER, LOAD_SERVERS
+    except:
+        MAIN_SERVER = NAMECOIND_SERVER
+        LOAD_SERVERS = []
+
+# --------------------------------------------------
+if BITCOIND_ENABLED:
+
+    BITCOIND_USE_HTTPS = True
+
+    try:
+        BITCOIND_PORT = os.environ['BITCOIND_PORT']
+        BITCOIND_SERVER = os.environ['BITCOIND_SERVER']
+        BITCOIND_USER = os.environ['BITCOIND_USER']
+        BITCOIND_PASSWD = os.environ['BITCOIND_PASSWD']
+        BITCOIND_WALLET_PASSPHRASE = os.environ['BITCOIND_WALLET_PASSPHRASE']
+
+    except:
+        BITCOIND_SERVER = 'btcd.onename.com'
+        BITCOIND_PORT = 8332
+        BITCOIND_USER = 'openname'
+        BITCOIND_PASSWD = 'opennamesystem'
+
+    try:
+        BITCOIND_WALLET_PASSPHRASE = os.environ['BITCOIND_WALLET_PASSPHRASE']
+    except:
+        BITCOIND_WALLET_PASSPHRASE = ''

--- a/rpc/coinrpc/namecoind_client.py
+++ b/rpc/coinrpc/namecoind_client.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+"""
+    coinrpc
+    ~~~~~
+
+    :copyright: (c) 2014 by Halfmoon Labs
+    :license: MIT, see LICENSE for more details.
+"""
+
+from commontools import utf8len, error_reply, get_json
+import json
+
+from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+from .config import NAMECOIND_SERVER, NAMECOIND_PORT, NAMECOIND_USER
+from .config import NAMECOIND_PASSWD, NAMECOIND_WALLET_PASSPHRASE
+from .config import NAMECOIND_USE_HTTPS, VALUE_MAX_LIMIT
+
+
+class NamecoindClient(object):
+
+    def __init__(self, server=NAMECOIND_SERVER, port=NAMECOIND_PORT,
+                 user=NAMECOIND_USER, passwd=NAMECOIND_PASSWD,
+                 use_https=NAMECOIND_USE_HTTPS,
+                 passphrase=NAMECOIND_WALLET_PASSPHRASE):
+
+        if use_https:
+            http_string = 'https://'
+        else:
+            http_string = 'http://'
+
+        self.obj = AuthServiceProxy(http_string + user + ':' + passwd + '@'
+                                    + server + ':' + str(port))
+
+        self.passphrase = passphrase
+        self.server = server
+
+    def __getattr__(self, name):
+        """ changes the behavior of underlying authproxy to return the error
+            from namecoind instead of raising JSONRPCException
+        """
+        func = getattr(self.__dict__['obj'], name)
+        if callable(func):
+            def my_wrapper(*args, **kwargs):
+                try:
+                    ret = func(*args, **kwargs)
+                except JSONRPCException as e:
+                    return e.error
+                else:
+                    return ret
+            return my_wrapper
+        else:
+            return func
+
+    # -----------------------------------
+    def blocks(self):
+
+        reply = self.getinfo()
+
+        if 'blocks' in reply:
+            return reply['blocks']
+
+        return None
+
+    # -----------------------------------
+    def name_filter(self, regex, check_blocks=36000,
+                    show_from=0, num_results=0):
+
+        try:
+            reply = self.obj.name_filter(regex, check_blocks,
+                                         show_from, num_results)
+        except JSONRPCException as e:
+            return e.error
+
+        return reply
+
+    # -----------------------------------
+    # Step-1 for registrering new names
+    def name_new(self, key, value):
+
+        # check if this key already exists
+        # namecoind lets you do name_new on keys that exist
+        if self.check_registration(key):
+            return error_reply("This key already exists")
+
+        if not self.unlock_wallet(self.passphrase):
+            return error_reply("Error unlocking wallet", 403)
+
+        # create new name
+        # returns a list of [tx, rand]
+        try:
+            reply = self.obj.name_new(key)
+        except JSONRPCException as e:
+            return e.error
+
+        return reply
+
+    # ----------------------------------------------
+    # step-2 for registering
+    def firstupdate(self, key, rand, value, tx=None):
+
+        if utf8len(value) > VALUE_MAX_LIMIT:
+            return error_reply("value larger than " + str(VALUE_MAX_LIMIT))
+
+        if not self.unlock_wallet(self.passphrase):
+            error_reply("Error unlocking wallet", 403)
+
+        try:
+            if tx is not None:
+                reply = self.obj.name_firstupdate(key, rand, tx, value)
+            else:
+                reply = self.obj.name_firstupdate(key, rand, value)
+        except JSONRPCException as e:
+            return e.error
+
+        return reply
+
+    # -----------------------------------
+    def name_update(self, key, value):
+
+        if utf8len(value) > VALUE_MAX_LIMIT:
+            return error_reply("value larger than " + str(VALUE_MAX_LIMIT))
+
+        if not self.unlock_wallet(self.passphrase):
+            error_reply("Error unlocking wallet", 403)
+
+        try:
+            # update the 'value'
+            reply = self.obj.name_update(key, value)
+        except JSONRPCException as e:
+            return e.error
+
+        return reply
+
+    # -----------------------------------
+    def name_transfer(self, key, new_address, value=None):
+        """ Check if this name exists and if it does, find the value field
+            note that update command needs an arg of <new value>.
+            in case we're simply transferring, need to obtain old value first
+        """
+
+        key_details = self.name_show(key)
+
+        if 'code' in key_details and key_details.get('code') == -4:
+            return error_reply("Key does not exist")
+
+        # get new 'value' if given, otherwise use the old 'value'
+        if value is None:
+            value = json.dumps(key_details['value'])
+
+        if not self.unlock_wallet(self.passphrase):
+            error_reply("Error unlocking wallet", 403)
+
+        # transfer the name (underlying call is still name_update)
+        try:
+            # update the 'value'
+            reply = self.obj.name_update(key, value, new_address)
+        except JSONRPCException as e:
+            return e.error
+
+        return reply
+
+    # -----------------------------------
+    def check_registration(self, key):
+
+        reply = self.name_show(key)
+
+        if 'code' in reply and reply.get('code') == -4:
+            return False
+        elif 'expired' in reply and reply.get('expired') == 1:
+            return False
+        else:
+            return True
+
+    # -----------------------------------
+    def validate_address(self, address):
+
+        reply = self.validateaddress(address)
+
+        reply['server'] = self.server
+
+        return reply
+
+    # -----------------------------------
+    def get_full_profile(self, key):
+
+        check_profile = self.name_show(key)
+
+        try:
+            check_profile = check_profile['value']
+        except:
+            return check_profile
+
+        if 'next' in check_profile:
+            try:
+                child_data = self.get_full_profile(check_profile['next'])
+            except:
+                return check_profile
+
+            del check_profile['next']
+
+            merged_data = {key: value for (key, value) in (
+                           check_profile.items() + child_data.items())}
+            return merged_data
+
+        else:
+            return check_profile
+
+    # -----------------------------------
+    def name_show(self, input_key):
+
+        try:
+            reply = self.obj.name_show(input_key)
+        except JSONRPCException as e:
+            return e.error
+
+        reply['value'] = get_json(reply['value'])
+
+        return reply
+
+    # -----------------------------------
+    def unlock_wallet(self, passphrase, timeout=100):
+
+        try:
+            reply = self.walletpassphrase(passphrase, timeout)
+        except JSONRPCException as e:
+            if 'code' in reply:
+                if reply['code'] == -17:
+                    return True
+                else:
+                    return False
+
+        return True
+
+    # -----------------------------------
+    def importprivkey(self, namecoinprivkey, label='import', rescan=False):
+
+        if not self.unlock_wallet(self.passphrase):
+            error_reply("Error unlocking wallet", 403)
+
+        try:
+            reply = self.obj.importprivkey(namecoinprivkey, label, rescan)
+        except JSONRPCException as e:
+            return e.error
+        return reply

--- a/rpc/coinrpc/namecoind_cluster.py
+++ b/rpc/coinrpc/namecoind_cluster.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""
+    coinrpc
+    ~~~~~
+
+    :copyright: (c) 2014 by Halfmoon Labs
+    :license: MIT, see LICENSE for more details.
+"""
+
+import os
+import sys
+import json
+
+from .config import NAMECOIND_SERVER
+
+
+from .namecoind_client import NamecoindClient
+
+from .config import NAMECOIND_SERVER, NAMECOIND_PORT, NAMECOIND_USER
+from .config import NAMECOIND_PASSWD
+from .config import MAIN_SERVER, LOAD_SERVERS
+
+from multiprocessing.pool import ThreadPool
+from commontools import log
+from commontools import pretty_print as pprint
+
+
+# -----------------------------------
+def pending_transactions(server):
+
+    """ get the no. of pending transactions (0 confirmations) on a server
+    """
+
+    namecoind = NamecoindClient(server, NAMECOIND_PORT,
+                                NAMECOIND_USER, NAMECOIND_PASSWD)
+
+    reply = namecoind.listtransactions("", 10000)
+
+    counter = 0
+
+    for i in reply:
+        if i['confirmations'] == 0:
+            counter += 1
+
+    return counter
+
+
+# -----------------------------------
+def check_address(address):
+
+    reply = {}
+    reply["server"] = None
+    reply["ismine"] = False
+    reply['registered'] = True
+
+    # --------------------------
+    def check_address_inner(server):
+
+        try:
+            namecoind = NamecoindClient(server, NAMECOIND_PORT,
+                                        NAMECOIND_USER, NAMECOIND_PASSWD)
+
+            info = namecoind.validate_address(address)
+        except Exception as e:
+            log.debug("Error in server %s", server)
+            log.debug(e)
+            return
+
+        if info['ismine'] is True:
+            reply['server'] = server
+            reply['ismine'] = True
+
+    # first check the main server
+    check_address_inner(MAIN_SERVER)
+
+    if reply['ismine'] is True:
+        return reply
+
+    # if not main server, check others
+    pool = ThreadPool(len(LOAD_SERVERS))
+
+    pool.map(check_address_inner, LOAD_SERVERS)
+    pool.close()
+    pool.join()
+
+    return reply
+
+
+# -----------------------------------
+def get_server(key):
+
+    """ given a key, get the IP address of the server that has the pvt key that
+        owns the name/key
+    """
+
+    namecoind = NamecoindClient(NAMECOIND_SERVER, NAMECOIND_PORT,
+                                NAMECOIND_USER, NAMECOIND_PASSWD)
+
+    info = namecoind.name_show(key)
+
+    if 'address' in info:
+        return check_address(info['address'])
+
+    response = {}
+    response["registered"] = False
+    response["server"] = None
+    response["ismine"] = False
+    return response
+
+
+# -----------------------------------
+def clean_wallet(server, clean_wallet):
+
+    namecoind = NamecoindClient(server)
+
+    reply = namecoind.listtransactions("", 10000)
+
+    counter = 0
+    counter_total = 0
+
+    track_confirmations = 1000
+
+    for i in reply:
+        counter_total += 1
+
+        if i['confirmations'] == 0:
+
+            counter += 1
+
+            if clean_wallet:
+                log.debug(namecoind.deletetransaction(i['txid']))
+
+        elif i['confirmations'] < track_confirmations:
+            track_confirmations = i['confirmations']
+
+    log.debug("%s: %s pending tx, %s confirmations (last tx), %s total tx"
+              % (server, counter, track_confirmations, counter_total))
+
+
+# -----------------------------------
+def rebroadcast_tx(server, raw_tx):
+
+    namecoind = NamecoindClient(server)
+
+    print namecoind.sendrawtransaction(raw_tx)
+
+
+# -----------------------------------
+def check_servers(servers, clean=False):
+
+    for server in servers:
+        clean_wallet(server, clean)
+
+
+# -----------------------------------
+def get_confirmations(server, tx):
+
+    namecoind = NamecoindClient(server)
+
+    reply = namecoind.listtransactions("",10000)
+
+    for entry in reply:
+
+        if entry['txid'] == tx:
+            return int(entry['confirmations'])
+
+    return 0
+
+# -----------------------------------
+if __name__ == '__main__':
+
+    try:
+        option = sys.argv[1]
+        if(option == '--clean'):
+            check_servers(LOAD_SERVERS, clean=True)
+        exit(0)
+    except:
+        pass
+
+    check_servers(LOAD_SERVERS, clean=False)
+    

--- a/rpc/coinrpc/scripts/setup_bitcoind.sh
+++ b/rpc/coinrpc/scripts/setup_bitcoind.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "Enter BITCOIND_SERVER:"
+read input
+export BITCOIND_SERVER=$input
+
+echo "Enter BITCOIND_PORT:"
+read input
+export BITCOIND_PORT=$input
+
+echo "Enter BITCOIND_USER:"
+read input
+export BITCOIND_USER=$input
+
+echo "Enter BITCOIND_PASSWD:"
+read input
+export BITCOIND_PASSWD=$input
+
+echo "Enter BITCOIND_WALLET_PASSPHRASE:"
+read input
+export BITCOIND_WALLET_PASSPHRASE=$input
+
+echo "Done"

--- a/rpc/coinrpc/scripts/setup_namecoind.sh
+++ b/rpc/coinrpc/scripts/setup_namecoind.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "Enter NAMECOIND_SERVER:"
+read input
+export NAMECOIND_SERVER=$input
+
+echo "Enter NAMECOIND_PORT:"
+read input
+export NAMECOIND_PORT=$input
+
+echo "Enter NAMECOIND_USER:"
+read input
+export NAMECOIND_USER=$input
+
+echo "Enter NAMECOIND_PASSWD:"
+read input
+export NAMECOIND_PASSWD=$input
+
+echo "Enter NAMECOIND_WALLET_PASSPHRASE:"
+read input
+export NAMECOIND_WALLET_PASSPHRASE=$input
+
+echo "Done"

--- a/rpc/requirements.txt
+++ b/rpc/requirements.txt
@@ -1,0 +1,2 @@
+commontools==0.1.0
+python-bitcoinrpc==0.1

--- a/rpc/setup.py
+++ b/rpc/setup.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""
+    coinrpc
+    ~~~~~
+
+    :copyright: (c) 2014 by Halfmoon Labs
+    :license: MIT, see LICENSE for more details.
+"""
+
+from setuptools import setup
+
+setup(
+    name='coinrpc',
+    version='0.1.0',
+    url='https://github.com/openname/coinrpc',
+    license='MIT',
+    author='Muneeb Ali (@muneeb) and Ibrahim Ahmed',
+    author_email='hello@halfmoonlabs.com',
+    description="Bitcoind and Namecoind python-rpc",
+    packages=['coinrpc'],
+    include_package_data=True,
+    install_requires=['python-bitcoinrpc==0.1',
+                      'commontools==0.1.0'],
+    zip_safe=False,
+    keywords=['python', 'bitcoin', 'namecoin', 'rpc'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+    ],
+)

--- a/rpc/tests/unit_tests.py
+++ b/rpc/tests/unit_tests.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+# Hack around absolute paths
+current_dir = os.path.abspath(os.path.dirname(__file__))
+parent_dir = os.path.abspath(current_dir + "/../")
+
+sys.path.insert(0, parent_dir)
+
+import unittest
+from coinrpc import namecoind, bitcoind
+
+
+class NamecoindTestCase(unittest.TestCase):
+
+    def test_connectivity(self):
+        """ Check if can connect to namecoind
+        """
+
+        blocks = namecoind.blocks()
+        self.assertIsNotNone(blocks, msg='Namecoind is not responding')
+
+    def test_full_profile(self):
+        """ Check if can connect to namecoind
+        """
+
+        key = 'u/muneeb'
+
+        profile = namecoind.get_full_profile(key)
+        self.assertIsInstance(profile, dict, msg='Could not get full profile')
+
+
+class BitcoindTestCase(unittest.TestCase):
+
+    def test_connectivity(self):
+        """ Check if can connect to bitcoind
+        """
+
+        blocks = bitcoind.blocks()
+        self.assertIsNotNone(blocks, msg='Bitcoind is not responding')
+
+if __name__ == '__main__':
+
+    unittest.main()


### PR DESCRIPTION
This commit adds the (simplified) coinrpc library to pybitcoin with the following properties:

1) Rewrote the commit history, so all coinrpc commits are local to rpc/ folder in the history and won't conflict with any commits (e.g., README.md in the root directory)
2) Removed commits for files/folders that are no longer relevant for coinrpc (e.g., the old source of namecoinrpc that was used at one point instead of AuthProxy, the secure deployment of coinrpc that was compiled with cython, old backups and irrelevant/temp folders etc)
3) Ensured that commit history is in chronological order relative to current pybitcoin commit history
