### PR TITLE
Dump raw transaction on error

### DIFF
--- a/pybitcoin/services/blockcypher.py
+++ b/pybitcoin/services/blockcypher.py
@@ -87,5 +87,6 @@ def broadcast_transaction(hex_tx, blockchain_client):
         reply['success'] = True
         return reply
     else:
-        err_str = 'Tx hash missing from blockcypher response: ' + str(data)
+        err_str = 'Tx hash missing from blockcypher response: ' + str(data) + "\n\n"
+        err_str = err_str + 'Raw transaction hex: ' + str(hex_tx)
         raise Exception(err_str)


### PR DESCRIPTION
Print out the raw hex transaction to help with debugging transactions that fail to send.

For example, the transaction below failed because it was trying to send zero bitcoin with a large fee, but this wasn't obvious to me until I examined the raw transaction.

```
{
    "error": "Exception: Tx hash missing from blockcypher response: {u'error': u'Error sending transaction: Transaction b4b13a918444a2a9c3dc4aa5db3e800fdc657f0f5f9386caca44de8ab2cbf0cb non standard: dust.'}",
    "traceback": [
        "Traceback (most recent call last):",
        "  File \"/usr/local/lib/python2.7/dist-packages/blockstore/blockstored.py\", line 587, in blockstore_name_update",
        "    tx_only=tx_only, blockchain_broadcaster=broadcaster_client_inst, user_public_key=user_public_key, testset=blockstore_opts['testset'])",
        "  File \"/usr/local/lib/python2.7/dist-packages/blockstore/lib/operations/update.py\", line 177, in broadcast",
        "    response = broadcast_transaction( signed_tx, blockchain_broadcaster )",
        "  File \"/usr/local/lib/python2.7/dist-packages/pybitcoin/transactions/network.py\", line 53, in broadcast_transaction",
        "    return blockcypher.broadcast_transaction(hex_tx, blockchain_client)",
        "  File \"/usr/local/lib/python2.7/dist-packages/pybitcoin/services/blockcypher.py\", line 91, in broadcast_transaction",
        "    raise Exception(err_str)",
        "Exception: Tx hash missing from blockcypher response: {u'error': u'Error sending transaction: Transaction b4b13a918444a2a9c3dc4aa5db3e800fdc657f0f5f9386caca44de8ab2cbf0cb non standard: dust.'}"
    ]
}
```
