### PR TITLE
Proper management of empty addresses. Fixes #46

### DIFF
--- a/pybitcoin/services/blockchain_info.py
+++ b/pybitcoin/services/blockchain_info.py
@@ -47,6 +47,12 @@ def get_unspents(address, blockchain_client=BlockchainInfoClient()):
         url = url + "&api_code=" + auth[0]
 
     r = requests.get(url, auth=auth)
+
+    if r.content == "No free outputs to spend":
+        return []
+    elif r.content == "Invalid Bitcoin Address":
+        raise Exception('Invalid Bitcoin address')
+
     try:
         unspents = r.json()["unspent_outputs"]
     except ValueError, e:


### PR DESCRIPTION
Manages most important blockchain.info error messages, which are not in JSON format but normal strings.

More error messages might be needed: unfortunately, I've failed in finding any place where they're fully documented.
