### PR TITLE
Add Ufocoin support for private keys

### DIFF
--- a/pybitcoin/privatekey.py
+++ b/pybitcoin/privatekey.py
@@ -146,3 +146,6 @@ class LitecoinPrivateKey(BitcoinPrivateKey):
 
 class NamecoinPrivateKey(BitcoinPrivateKey):
     _pubkeyhash_version_byte = 52
+    
+class UfocoinPrivateKey(BitcoinPrivateKey):
+    _pubkeyhash_version_byte = 27


### PR DESCRIPTION
History: 

Ran into an issue with the old Ufocoin paper wallet generator where it created invalid WIF keys. Added private key support for Ufocoin to easily create valid keys for anyone else that might have been hit by the same bug and needs to convert keys properly.